### PR TITLE
adding timeout for get_url in samples/ansible.cfg

### DIFF
--- a/samples/ansible.cfg
+++ b/samples/ansible.cfg
@@ -1,0 +1,9 @@
+[defaults]
+hostfile = .ansible_hosts
+
+# In some configurations this won't work, use only if your config permits.
+[ssh_connection]
+pipelining = True  # Speeds up connections but only if requiretty is not enabled for sudo
+
+[get_url]
+timeout=240


### PR DESCRIPTION
adds:

[get_url]
timeout=240
